### PR TITLE
Don't log Sonar Job in queue history

### DIFF
--- a/app/Queue/Worker.php
+++ b/app/Queue/Worker.php
@@ -32,7 +32,10 @@ class Worker extends OriginalWorker
         } catch (Throwable $e) {
             $this->recordJobException($e);
         } finally {
-            $this->recordJobEnd($startTime);
+            // Don't log Sonar Job in queue history
+            if($job->resolveName() != "Eyewitness\\Eye\\Queue\\Jobs\\Sonar") {
+                $this->recordJobEnd($startTime);
+            }
         }
     }
 }


### PR DESCRIPTION
On every eyewitness:poll, process_count is updated with +1 because of Sonar injection. Is possible to avoid this in other manner, but for me works like this.